### PR TITLE
Allocation of static threads implementation 

### DIFF
--- a/composition_scripts/unit_static_thds.toml
+++ b/composition_scripts/unit_static_thds.toml
@@ -18,12 +18,14 @@ constructor = "booter"
 [[components]]
 name = "sched"
 img  = "sched.pfprr_quantum_static"
+constants = [{variable = "MAX_NUM_STATIC_THD_COMP", value = "4"}]
 deps = [{srv = "capmgr", interface = "init"}, {srv = "capmgr", interface = "capmgr"}, {srv = "capmgr", interface = "memmgr"}]
 implements = [{interface = "sched"}, {interface = "init"}]
 constructor = "booter"
 
 [[components]]
 name = "clientcomp"
+constants = [{variable = "MAX_NUM_STATIC_THD_COMP", value = "4"}]
 img  = "tests.unit_static_thds"
 deps = [{srv = "sched", interface = "init"}, {srv = "sched", interface = "sched"}, {srv = "capmgr", interface = "capmgr_create"}]
 constructor = "booter"

--- a/composition_scripts/unit_static_thds.toml
+++ b/composition_scripts/unit_static_thds.toml
@@ -1,0 +1,37 @@
+[system]
+description = "Simplest system with both capability manager and scheduler, from unit_schedcomp.sh"
+
+[[components]]
+name = "booter"
+img  = "no_interface.llbooter"
+implements = [{interface = "init"}, {interface = "addr"}]
+deps = [{srv = "kernel", interface = "init", variant = "kernel"}]
+constructor = "kernel"
+
+[[components]]
+name = "capmgr"
+img  = "capmgr.simple"
+deps = [{srv = "booter", interface = "init"}, {srv = "booter", interface = "addr"}]
+implements = [{interface = "capmgr"}, {interface = "init"}, {interface = "memmgr"}, {interface = "capmgr_create"}]
+constructor = "booter"
+
+[[components]]
+name = "sched"
+img  = "sched.pfprr_quantum_static"
+deps = [{srv = "capmgr", interface = "init"}, {srv = "capmgr", interface = "capmgr"}, {srv = "capmgr", interface = "memmgr"}]
+implements = [{interface = "sched"}, {interface = "init"}]
+constructor = "booter"
+
+[[components]]
+name = "clientcomp"
+img  = "tests.unit_static_thds"
+deps = [{srv = "sched", interface = "init"}, {srv = "sched", interface = "sched"}, {srv = "capmgr", interface = "capmgr_create"}]
+constructor = "booter"
+
+[[virt_resources]]
+name = "sched_init"
+server = "sched"
+resources = [
+    {name = "static_hi", param = { core = "0", priority = "3" }, clients = [{comp = "clientcomp", access = "whatever1", name = "name_static_hi"}]},
+    {name = "static_lo", param = { core = "2", priority = "4" }, clients = [{comp = "clientcomp", access = "whatever3", name = "name_static_lo"}]}
+]

--- a/src/components/implementation/sched/pfprr_quantum_static/init.c
+++ b/src/components/implementation/sched/pfprr_quantum_static/init.c
@@ -141,6 +141,7 @@ create_static_thds(unsigned int coreid)
 			// Add the thread to the static_thds array
 			// to wake up the thread when the client triggers the scheduler
 			idx = atoi(id_str);
+			assert(idx <= MAX_NUM_STATIC_THD_COMP);
 			static_thds_arr[compid][--idx] = t;	
 		}
 	}	

--- a/src/components/implementation/sched/pfprr_quantum_static/main.c
+++ b/src/components/implementation/sched/pfprr_quantum_static/main.c
@@ -208,6 +208,25 @@ sched_thd_wakeup(thdid_t tid)
 	return thd_wakeup(t);
 }
 
+extern struct slm_thd *static_thds_arr[MAX_NUM_COMPS][MAX_NUM_STATIC_THD_COMP];
+
+int
+sched_thd_wakeup_static(compid_t cid, unsigned int idx)
+{
+	struct slm_thd *t = NULL;
+	
+	assert(idx > 0);
+	assert(idx < 3);
+
+	// TODO: Is there any way to find callers compid?
+	t = static_thds_arr[cid][--idx];
+	if (!t) {
+		return -1;
+	} 
+
+	return thd_wakeup(t);	
+}
+
 int
 sched_debug_thd_state(thdid_t tid)
 {
@@ -640,6 +659,8 @@ cos_parallel_init(coreid_t cid, int init_core, int ncores)
 	if (!r) BUG();
 	sched_thd_param_set(ipitid, sched_param_pack(SCHEDP_PRIO, SLM_IPI_THD_PRIO));
 	ck_ring_init(&ipi_data->ring, PAGE_SIZE / sizeof(struct slm_ipi_event));
+
+	// XXX: ESMA call it here?
 }
 
 void

--- a/src/components/implementation/sched/pfprr_quantum_static/main.c
+++ b/src/components/implementation/sched/pfprr_quantum_static/main.c
@@ -216,7 +216,7 @@ sched_thd_wakeup_static(compid_t cid, unsigned int idx)
 	struct slm_thd *t = NULL;
 	
 	assert(idx > 0);
-	assert(idx < 3);
+	assert(idx < MAX_NUM_STATIC_THD_COMP);
 
 	// TODO: Is there any way to find callers compid?
 	t = static_thds_arr[cid][--idx];

--- a/src/components/implementation/sched/pfprr_quantum_static/slm_modules.h
+++ b/src/components/implementation/sched/pfprr_quantum_static/slm_modules.h
@@ -15,6 +15,7 @@ struct slm_thd_container *slm_thd_alloc(thd_fn_t fn, void *data, thdcap_t *thd, 
 struct slm_thd_container *slm_thd_alloc_in(compid_t cid, thdclosure_index_t idx, thdcap_t *thd, thdid_t *tid);
 struct slm_thd *thd_alloc(thd_fn_t fn, void *data, sched_param_t *parameters, int reschedule);
 struct slm_thd *thd_alloc_in(compid_t id, thdclosure_index_t idx, sched_param_t *parameters, int reschedule);
+struct slm_thd *thd_alloc_in_static(compid_t id, thdclosure_index_t idx, sched_param_t *parameters);
 
 
 #endif	/* SLM_MODULES_H */

--- a/src/components/implementation/tests/unit_static_thds/Makefile
+++ b/src/components/implementation/tests/unit_static_thds/Makefile
@@ -1,0 +1,18 @@
+# Required variables used to drive the compilation process. It is OK
+# for many of these to be empty.
+#
+# The set of interfaces that this component exports for use by other
+# components. This is a list of the interface names.
+INTERFACE_EXPORTS =
+# The interfaces this component is dependent on for compilation (this
+# is a list of directory names in interface/)
+INTERFACE_DEPENDENCIES = init sched
+# The library dependencies this component is reliant on for
+# compilation/linking (this is a list of directory names in lib/)
+LIBRARY_DEPENDENCIES = component time
+# Note: Both the interface and library dependencies should be
+# *minimal*. That is to say that removing a dependency should cause
+# the build to fail. The build system does not validate this
+# minimality; that's on you!
+
+include Makefile.subsubdir

--- a/src/components/implementation/tests/unit_static_thds/unit_comp_static_thds.c
+++ b/src/components/implementation/tests/unit_static_thds/unit_comp_static_thds.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2018, Phani Gadepalli and Gabriel Parmer, GWU, gparmer@gwu.edu.
+ *
+ * This uses a two clause BSD License.
+ */
+
+#include <llprint.h>
+#include <res_spec.h>
+#include <sched.h>
+#include <cos_time.h>
+#include <cos_component.h>
+#include <initargs.h>
+
+#define SL_FPRR_NPRIOS 32
+#define LOWEST_PRIORITY (SL_FPRR_NPRIOS - 1)
+#define LOW_PRIORITY (LOWEST_PRIORITY - 1)
+
+enum {
+	STATIC_HI_STEP,
+	STATIC_LO_STEP,
+	DYNAMIC_STEP,
+	NUM_OF_STEPS
+} test_steps_t;
+
+int do_continue = 1;
+int test_failed = 0;
+int test_passed[NUM_OF_STEPS] = {0, 0, 0};
+
+// Function pointer array for static threads
+static void (*static_thd_fn[MAX_NUM_STATIC_THD_COMP])(void);
+
+static void static_thread_hi(void);
+static void static_thread_lo(void);
+
+static void
+dynamic_thread(void *d)
+{
+	PRINTLOG(PRINT_DEBUG, "Dynamic thread running on core %ld\n", cos_cpuid());
+	PRINTLOG(PRINT_DEBUG, "Test step %d passed\n", DYNAMIC_STEP);
+	test_passed[DYNAMIC_STEP] = 1;
+	sched_thd_block(0);
+}
+
+int
+cos_init(void)
+{
+	PRINTLOG(PRINT_DEBUG, "Unit-test creation of static threads\n");
+	
+	// Parse the static thread parameters from initargs.c
+	struct initargs static_thds, curr_thd;
+	struct initargs_iter i;
+	int ret, cont, cont2;
+
+	ret = args_get_entry("virt_resources/sched_init", &static_thds);
+	if(ret == 0) {
+		for( cont = args_iter(&static_thds, &i, &curr_thd) ; cont ; cont = args_iter_next(&i, &curr_thd) ) {
+			thdclosure_index_t idx;
+			char *id_str, *name_str = NULL;
+
+			// Get the thread idx
+			id_str = args_get_from("id", &curr_thd);
+			assert(id_str != NULL && atoi(id_str) > 0);
+			idx = atoi(id_str);
+
+			// Get the name
+			name_str = args_get_from("name", &curr_thd);
+			assert(name_str != NULL);
+			
+			// Decrement idx to match the array index
+			--idx;
+			if(strcmp(name_str, "name_static_hi") == 0) {
+				static_thd_fn[idx] = static_thread_hi;
+			} else if(strcmp(name_str, "name_static_lo") == 0) {
+				static_thd_fn[idx] = static_thread_lo;
+			}
+		}
+	}
+
+	return 0;
+}
+
+int
+main(void)
+{
+	thdid_t dyn_thdid;
+	int ret;
+
+	dyn_thdid = sched_thd_create(dynamic_thread, NULL);
+	sched_thd_param_set(dyn_thdid, sched_param_pack(SCHEDP_PRIO, LOWEST_PRIORITY));
+
+	// Wake up the static threads
+	compid_t compid = cos_compid();
+	ret = sched_thd_wakeup_static(compid, 1); // High priority static thread
+	assert(ret == 0);
+	ret = sched_thd_wakeup_static(compid, 2); // Low priority static thread
+	assert(ret == 0);
+
+	while (do_continue && !test_failed) {
+		cycles_t wakeup;
+
+		wakeup = time_now() + time_usec2cyc(1000 * 1000);
+		sched_thd_block_timeout(0, wakeup);
+
+		do_continue = !(test_passed[STATIC_HI_STEP] 
+						&& test_passed[STATIC_LO_STEP] 
+						&& test_passed[DYNAMIC_STEP]);
+	}
+
+	if (test_failed) {
+		PRINTLOG(PRINT_ERROR, "Test failed in one or more steps\n");
+	} else {
+		PRINTLOG(PRINT_DEBUG, "Test passed\n");
+	}
+	return 0;
+}
+
+static void
+static_thread_hi(void)
+{
+	// We expect this to run on core 1
+	PRINTLOG(PRINT_DEBUG, "High priority static thread is running on core %ld\n", cos_cpuid());
+	if (cos_cpuid() != 0) {
+		PRINTLOG(PRINT_ERROR, "Test failed! High priority static thread is not running on core 0\n");
+		test_failed = 1;
+	} else {
+		PRINTLOG(PRINT_DEBUG, "Test step %d passed, spinning\n", STATIC_HI_STEP);
+		test_passed[STATIC_HI_STEP] = 1;
+	}
+	sched_thd_block(0);
+}
+
+static void
+static_thread_lo(void)
+{
+	//We expect this to run on core 2
+	PRINTLOG(PRINT_DEBUG, "Low priority static thread is running on core %ld\n", cos_cpuid());
+	if (cos_cpuid() != 2) {
+		PRINTLOG(PRINT_ERROR, "Test failed! Low priority static thread is not running on core 2\n");
+		test_failed = 1;
+	} else {
+		PRINTLOG(PRINT_DEBUG, "Test step %d passed\n", STATIC_LO_STEP);
+		test_passed[STATIC_LO_STEP] = 1;
+	}
+	sched_thd_block(0);
+}
+
+int
+cos_thd_entry_static(u32_t idx)
+{
+	PRINTLOG(PRINT_DEBUG, "Component %ld: Static thread idx %d\n", cos_compid(), idx);
+	// Increment idx to match the thread index
+	static_thd_fn[--idx]();
+
+	// Should never reach here
+	assert(0);
+
+	return 0;
+}
+
+
+

--- a/src/components/implementation/tests/unit_static_thds/unit_comp_static_thds.c
+++ b/src/components/implementation/tests/unit_static_thds/unit_comp_static_thds.c
@@ -26,8 +26,8 @@ int do_continue = 1;
 int test_failed = 0;
 int test_passed[NUM_OF_STEPS] = {0, 0, 0};
 
-// Function pointer array for static threads
-static void (*static_thd_fn[MAX_NUM_STATIC_THD_COMP])(void);
+// Array to store the idx of the static threads
+unsigned int static_thread_idx[MAX_NUM_STATIC_THD_COMP] = {0};
 
 static void static_thread_hi(void);
 static void static_thread_lo(void);
@@ -66,12 +66,10 @@ cos_init(void)
 			name_str = args_get_from("name", &curr_thd);
 			assert(name_str != NULL);
 			
-			// Decrement idx to match the array index
-			--idx;
 			if(strcmp(name_str, "name_static_hi") == 0) {
-				static_thd_fn[idx] = static_thread_hi;
+				static_thread_idx[STATIC_HI_STEP] = idx;
 			} else if(strcmp(name_str, "name_static_lo") == 0) {
-				static_thd_fn[idx] = static_thread_lo;
+				static_thread_idx[STATIC_LO_STEP] = idx;
 			}
 		}
 	}
@@ -145,11 +143,15 @@ static_thread_lo(void)
 }
 
 int
-cos_thd_entry_static(u32_t idx)
+cos_thd_entry_static(unsigned int idx)
 {
 	PRINTLOG(PRINT_DEBUG, "Component %ld: Static thread idx %d\n", cos_compid(), idx);
 	// Increment idx to match the thread index
-	static_thd_fn[--idx]();
+	if (idx == static_thread_idx[STATIC_HI_STEP]) {
+		static_thread_hi();
+	} else if (idx == static_thread_idx[STATIC_LO_STEP]) {
+		static_thread_lo();
+	}
 
 	// Should never reach here
 	assert(0);

--- a/src/components/interface/sched/sched.h
+++ b/src/components/interface/sched/sched.h
@@ -27,6 +27,8 @@ int      sched_thd_yield_to(thdid_t t);
 int      COS_STUB_DECL(sched_thd_yield_to)(thdid_t t);
 int      sched_thd_wakeup(thdid_t t);
 int      COS_STUB_DECL(sched_thd_wakeup)(thdid_t t);
+int      sched_thd_wakeup_static(compid_t cid, unsigned int idx);
+int      COS_STUB_DECL(sched_thd_wakeup_static)(compid_t cid, unsigned int idx);
 int      sched_debug_thd_state(thdid_t t);
 int      COS_STUB_DECL(sched_debug_thd_state)(thdid_t t);
 int      sched_thd_block(thdid_t dep_id);

--- a/src/components/interface/sched/stubs/stubs.S
+++ b/src/components/interface/sched/stubs/stubs.S
@@ -10,6 +10,7 @@
 cos_asm_stub(sched_get_cpu_freq);
 cos_asm_stub(sched_thd_yield_to);
 cos_asm_stub(sched_thd_wakeup);
+cos_asm_stub(sched_thd_wakeup_static);
 cos_asm_stub(sched_debug_thd_state);
 cos_asm_stub(sched_thd_block);
 cos_asm_stub(sched_blkpt_alloc);

--- a/src/components/lib/component/cos_component.c
+++ b/src/components/lib/component/cos_component.c
@@ -362,8 +362,9 @@ cos_upcall_fn(upcall_type_t t, void *arg1, void *arg2, void *arg3)
 		} else {
 			word_t idx = (word_t)arg1 - 1;
 			if (idx >= COS_THD_INIT_REGION_SIZE) {
-				/* This means static defined entry */
-				cos_thd_entry_static(idx - COS_THD_INIT_REGION_SIZE);
+				/* This means static defined entry 
+				 * idx should be the static thread id */
+				cos_thd_entry_static(idx + 1 - COS_THD_INIT_REGION_SIZE);
 			} else {
 				/* Execute dynamic allocated entry. */
 				cos_thd_entry_exec(idx);

--- a/src/components/lib/component/cos_component.c
+++ b/src/components/lib/component/cos_component.c
@@ -226,6 +226,8 @@ cos_thd_entry_exec(u32_t idx)
 	__thd_init_data[idx].data = NULL;
 	__thd_init_data[idx].fn   = NULL;
 
+	/* It is hard to trace the error if fn is NULL */
+	assert(fn != NULL);
 	(fn)(data);
 }
 

--- a/src/composer/src/main.rs
+++ b/src/composer/src/main.rs
@@ -18,6 +18,7 @@ mod resources;
 mod symbols;
 mod syshelpers;
 mod tot_order;
+mod virt_resources;
 
 use address_assignment::AddressAssignmentx86_64;
 use build::DefaultBuilder;
@@ -30,6 +31,7 @@ use properties::CompProperties;
 use resources::ResAssignPass;
 use std::env;
 use tot_order::CompTotOrd;
+use virt_resources::VirtResAnalysis;
 
 pub fn exec() -> Result<(), String> {
     let mut args = env::args();
@@ -58,6 +60,7 @@ pub fn exec() -> Result<(), String> {
 
     sys.add_parsed(SystemSpec::transition(&sys, &mut build)?);
     sys.add_named(CompTotOrd::transition(&sys, &mut build)?);
+    sys.add_virt_res(VirtResAnalysis::transition(&sys, &mut build)?);
     sys.add_address_assign(AddressAssignmentx86_64::transition(&sys, &mut build)?);
     sys.add_properties(CompProperties::transition(&sys, &mut build)?);
     sys.add_restbls(ResAssignPass::transition(&sys, &mut build)?);

--- a/src/composer/src/virt_resources.rs
+++ b/src/composer/src/virt_resources.rs
@@ -1,0 +1,66 @@
+use passes::{
+    BuildState, VirtResPass, VirtResName, VirtResWitID, VirtualResource, SystemState, Transition,
+};
+use std::collections::BTreeMap;
+
+use cossystem::Clients;
+
+pub struct VirtResAnalysis {
+    virt_res_with_id: BTreeMap<VirtResName,VirtualResource>,
+}
+
+impl VirtResPass for VirtResAnalysis {
+    fn virt_res_with_id(&self) -> &BTreeMap<VirtResName,VirtualResource> {
+        &self.virt_res_with_id
+    }
+}
+
+impl Transition for VirtResAnalysis {
+    fn transition(s: &SystemState, _b: &mut dyn BuildState) -> Result<Box<Self>, String> {
+        let mut virt_res_with_id = BTreeMap::new();
+        let mut id_counter = 1;
+
+        // Iterate over the virtual resources in the system state
+        let vr_map = s.get_spec().virtual_resources();
+
+        for (_key, vr) in vr_map {
+            let mut virt_res_list = Vec::new();
+
+            if vr.server == "chanmgr" {
+                id_counter = 5;
+            }
+            
+            // Iterate over each VirtRes and add a unique ID
+            for virtres in &vr.resources {
+                let virt_resource_id = id_counter.to_string();
+                id_counter += 1;
+
+                // Create a new VirtResWitID with the generated ID
+                let virt_res_with_id = VirtResWitID {
+                    virt_resource_id,
+                    param: virtres.param.clone(),
+                    clients: virtres.clients.iter().map(|client| Clients {
+                        comp: client.comp.clone(),
+                        access: client.access.clone(),
+                        name: client.name.clone(),
+                        symbol: client.symbol.clone(),
+                    }).collect(),                };
+
+                virt_res_list.push(virt_res_with_id);
+            }
+
+            // Create a new VirtualResource with the list of VirtResWitID
+            let virtual_resource = VirtualResource {
+                name: vr.name.clone(),
+                server: vr.server.clone(),
+                resources: virt_res_list,
+            };
+
+            virt_res_with_id.insert(vr.name.clone(), virtual_resource);
+        }
+
+        Ok(Box::new(VirtResAnalysis {
+            virt_res_with_id,
+        }))
+    }
+}

--- a/src/kernel/include/shared/consts.h
+++ b/src/kernel/include/shared/consts.h
@@ -33,10 +33,9 @@
 #define MAX_SERVICE_DEPTH 31
 #define MAX_NUM_THREADS (25 * NUM_CPU)
 
-/* TODO: Automatically define via composer */
 /* Maximum number of static threads per component */
 #ifndef MAX_NUM_STATIC_THD_COMP 
-#define MAX_NUM_STATIC_THD_COMP 2
+#define MAX_NUM_STATIC_THD_COMP 0
 #endif
 
 /*

--- a/src/kernel/include/shared/consts.h
+++ b/src/kernel/include/shared/consts.h
@@ -33,6 +33,12 @@
 #define MAX_SERVICE_DEPTH 31
 #define MAX_NUM_THREADS (25 * NUM_CPU)
 
+/* TODO: Automatically define via composer */
+/* Maximum number of static threads per component */
+#ifndef MAX_NUM_STATIC_THD_COMP 
+#define MAX_NUM_STATIC_THD_COMP 2
+#endif
+
 /*
  * A single thread's stack size is 2^17 = 128kb by default
  */


### PR DESCRIPTION
### Summary of this Pull Request (PR)

User defines the static threads in the toml file like below:
```
[[virt_resources]]
name = "sched_init"
server = "sched"
resources = [
    {name = "static_hi", param = { core = "0", priority = "3" }, clients = [{comp = "clientcomp", access = "whatever1", name = "name_static_hi"}]},
    {name = "static_lo", param = { core = "2", priority = "4" }, clients = [{comp = "clientcomp", access = "whatever3", name = "name_static_lo"}]}
]
```
- Just before all other components initialize, scheduler loop allocates and blocks the static threads. (**thd_alloc_in_static()**)
- Client components can use **sched_thd_wakeup_static()** with the static thd id.
- Client component uses names in initargs.c to relate threads with their id.
- Client component overrides **cos_thd_entry_static()** function to define the entry point.

### Intent for your PR

Choose one (Mandatory):

- [x] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [ ] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@spadek67424 , @mbai1010 

### Testing

I've tested the code using the following test programs (provide list here):

- [ ] micro_booter
- [x] unit_pingpong
- [x] unit_schedtests
- [x] unit_static_thds
- [ ] ...(add others here)
